### PR TITLE
Enable FindPoco.cmake to detect NetSSL. Fix list of supported components

### DIFF
--- a/cmake/FindPoco.cmake
+++ b/cmake/FindPoco.cmake
@@ -4,12 +4,13 @@
 #
 # Util (loaded by default)
 # Foundation (loaded by default)
+# JSON
 # XML
 # Zip
 # Crypto
 # Data
 # Net
-# NetSSL_OpenSSL
+# NetSSL
 # OSP
 #
 # Usage:
@@ -114,10 +115,19 @@ foreach( component ${components} )
 		
 	# include directory for the component
 	if(NOT Poco_${component}_INCLUDE_DIR)
+		if(component STREQUAL "NetSSL")
+			set(component_INCLUDE_NAMES
+				"Poco/Net/NetSSL.h"
+			)
+		else()
+			set(component_INCLUDE_NAMES
+				"Poco/${component}.h" # e.g. Foundation.h
+				"Poco/${component}/${component}.h" # e.g. OSP/OSP.h Util/Util.h
+			)
+		endif()
 		find_path(Poco_${component}_INCLUDE_DIR
 			NAMES 
-				Poco/${component}.h 	# e.g. Foundation.h
-				Poco/${component}/${component}.h # e.g. OSP/OSP.h Util/Util.h
+				${component_INCLUDE_NAMES}
 			HINTS
 				${Poco_ROOT_DIR}
 			PATH_SUFFIXES


### PR DESCRIPTION
Installed header for component NetSSL_OpenSSL is located at Poco/Net/NetSSL.h, i.e. header and parent directory names do not match, and the _OpenSSL postfix must be omitted.

This change introduces a special name pattern for these NetSSL anomalies and corrects the list of supported components by stripping _OpenSSL postfix. Also add JSON as retrievable component, which works fine both with and without this change.